### PR TITLE
Refer to correct arrow for right assignment in R

### DIFF
--- a/dev-guide/r.md
+++ b/dev-guide/r.md
@@ -33,7 +33,7 @@ Lead author: Pieter Huybrechts
 > - R code MUST follow the [rOpenSci recommendations regarding commonly used dependencies](https://devguide.ropensci.org/building.html#recommended-scaffolding).
 > - Dependencies on other packages MUST be declared in a DESCRIPTION file.
 > - R code written MUST follow the [tidyverse style guide](https://style.tidyverse.org/).
-> - R code MUST NOT make use of the right side assignment operator `-->`.
+> - R code MUST NOT make use of the right side assignment operator `->`.
 > - All R code MUST reach a test coverage of at least 75% calculated using [covr](https://covr.r-lib.org/).
 > - Unit tests MUST be implemented using the [testthat](https://testthat.r-lib.org/) package.
 > - Shiny apps SHOULD make use of [shinytest](https://rstudio.github.io/shinytest/).


### PR DESCRIPTION
Although `-->` renders nicely as an arrow, the actual assignment operator that mustn't be used is `->`, in this PR I've removed a single character. 

Reference: https://style.tidyverse.org/syntax.html?#assignment and https://devguide.ropensci.org/building.html#code-style
