### PR TITLE
Remove typo

### DIFF
--- a/pages/dev-guide.md
+++ b/pages/dev-guide.md
@@ -446,7 +446,7 @@ Adding a dependency to your `DESCRIPTION` file is easy using [usethis](https://u
 usethis::use_package("dplyr")
 ```
 
-Refer to the [rOpenSci recommendations](https://devguide.ropensci.org/pkg_building.html#recommended-scaffolding) for common scaffolding for more suggestions.
+Refer to the [rOpenSci recommendations](https://devguide.ropensci.org/pkg_building.html#recommended-scaffolding) for more suggestions.
 
 {:#r-style}
 ### Code style


### PR DESCRIPTION
Hi 👋 
I think we should opt for "for more suggestions". An alternative could be: "for more scaffolding".  But not both in the same sentence. It sounds like a typo.