### PR TITLE
Add dissMapR and invasiMapR software pages

### DIFF
--- a/src/content/docs/software/dissmapr.md
+++ b/src/content/docs/software/dissmapr.md
@@ -1,0 +1,12 @@
+---
+title: dissMapR R package
+authors: Sandra MacFadyen
+---
+
+Tutorials for the "dissMapR” R package, a tool to assess, map, and predict compositional dissimilarity and biodiversity turnover.
+
+- [Overview of dissMapR functions](https://b-cubed-eu.github.io/dissmapr/)
+- [Data Access and Preparation](https://b-cubed-eu.github.io/dissmapr/)
+- [Metric Computation](https://b-cubed-eu.github.io/dissmapr/)
+- [Modelling and Prediction](https://b-cubed-eu.github.io/dissmapr/)
+- [Mapping and Visualisation](https://b-cubed-eu.github.io/dissmapr/)

--- a/src/content/docs/software/invasimapr.md
+++ b/src/content/docs/software/invasimapr.md
@@ -1,0 +1,12 @@
+---
+title: invasiMapR R package
+authors: Sandra MacFadyen
+---
+
+Tutorials for the "invasiMapR” R package, a tool to quantify and map invasion fitness and invasibility.
+
+- [Overview of invasiMapR functions](https://b-cubed-eu.github.io/invasimapr/)
+- [Data Access and Preparation](https://b-cubed-eu.github.io/invasimapr/)
+- [Functional Dissimilarity and Community Trait Profiles](https://b-cubed-eu.github.io/invasimapr/)
+- [Interaction Strength](https://b-cubed-eu.github.io/invasimapr/)
+- [Invasiveness](https://b-cubed-eu.github.io/invasimapr/)


### PR DESCRIPTION
Add first pages for new dissMapR and invasiMap R packages in development. Software repositories 'https://b-cubed-eu.github.io/dissmapr/' and 'https://b-cubed-eu.github.io/invasimapr' still to be created, so links won't work yet. With the new 'Astro + Starlight project' structure, I'm not sure where to update navigation tab.