### PR TITLE
Add link to b3verse website

### DIFF
--- a/src/content/docs/guides/b3verse.Rmd
+++ b/src/content/docs/guides/b3verse.Rmd
@@ -11,6 +11,10 @@ knit: (function(inputFile, ...) {
 
 <!-- b3verse.md is generated from b3verse.Rmd Please edit that file -->
 
+:::tip[Explore]
+Explore the [b3verse website](https://b-cubed-eu.r-universe.dev/).
+:::
+
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,

--- a/src/content/docs/guides/b3verse.md
+++ b/src/content/docs/guides/b3verse.md
@@ -11,6 +11,10 @@ knit: (function(inputFile, ...) {
 
 <!-- b3verse.md is generated from b3verse.Rmd Please edit that file -->
 
+:::tip[Explore]
+Explore the [b3verse website](https://b-cubed-eu.r-universe.dev/).
+:::
+
 
 
 [![name status badge](https://b-cubed-eu.r-universe.dev/badges/:name?color=6CDDB4)](https://b-cubed-eu.r-universe.dev/)


### PR DESCRIPTION
The link to b3verse is currently a bit hidden in the b3verse guide (it's under `dedicated R-universe platform`). I've added a call-out add the top to make it easier to find the website:

<img width="713" height="592" alt="Screenshot 2025-08-20 at 12 44 03" src="https://github.com/user-attachments/assets/03563220-d465-441f-bedc-a2f7c825df76" />
