### PR TITLE
Remove "All participants to software MUST abide by its code of conduct."

### DIFF
--- a/src/content/docs/guides/software-development.md
+++ b/src/content/docs/guides/software-development.md
@@ -193,7 +193,6 @@ A repository can have additional README files beyond the one in the root. These 
 
 :::tip[B-Cubed software requirements]
 - All software MUST have a code of conduct (as a `CODE_OF_CONDUCT.md` file following the [Contributor Covenant template](https://www.contributor-covenant.org/)).
-- All participants to software MUST abide by its code of conduct.
 - Maintainers MUST watch the repository they maintain.
 - Code contributions MUST follow the GitHub flow.
 - The main branch MUST contain the software code in a state that can be installed without issue.
@@ -211,7 +210,7 @@ All steps below can be completed in the browser. For more information on GitHub 
 
 A [code of conduct](https://opensource.guide/code-of-conduct/) is a document that establishes expectations for behaviour from all software participants. Adopting and enforcing it can help to create a safe and positive working space.
 
-All software MUST have a code of conduct, as a `CODE_OF_CONDUCT.md` file following the [Contributor Covenant](https://www.contributor-covenant.org/) template. All participants to software MUST abide by its code of conduct.
+All software MUST have a code of conduct, as a `CODE_OF_CONDUCT.md` file following the [Contributor Covenant](https://www.contributor-covenant.org/) template.
 
 To add a `CODE_OF_CONDUCT.md`:
 


### PR DESCRIPTION
- This requirement is very hard to assess in the software quality assessment
- Reducing this statement to a SHOULD is also not what we intend, so I removed it completely
- It is implied by having a code of conduct